### PR TITLE
Add layout validations

### DIFF
--- a/notes/validation_ideas.md
+++ b/notes/validation_ideas.md
@@ -1,0 +1,15 @@
+*** Validation ideas
+
+- confirm multimeasure rests span measures that exist
+- confirm measure counts in each part (optionally: it may be permissible to have different numbers of measures per part. need to check)
+- confirm layouts in "scores" have been defined in "layouts". This is required by the MNX doc and not enforced by the schema.
+- confirm measures exist in staff systems
+- confirm "part" and "labelref" values in staff and staff source objects contain valid values/part references (part ids)
+
+*** Questions and Suggestions
+
+- more symbol styles for groups (in particular, deskBracket)
+- since the staff object has a "labelref" property, should it not also have a "part" property?
+- staff group objects need a labelref alternative (and "part" that it references).
+- there needs to be a mechanism to specify automatic name/shortName for "labelref" values.
+

--- a/notes/validation_ideas.md
+++ b/notes/validation_ideas.md
@@ -5,11 +5,17 @@
 - confirm layouts in "scores" have been defined in "layouts". This is required by the MNX doc and not enforced by the schema.
 - confirm measures exist in staff systems
 - confirm "part" and "labelref" values in staff and staff source objects contain valid values/part references (part ids)
+- valid values for enums (some of these are enforced by the schema; we'll need to check):
+    - "labelref" (not enforced)
+    - "stem" (staff source stem direction) -- enforced by schema
+    - "symbol" (group bracket) -- enforced by schema
 
 *** Questions and Suggestions
 
 - more symbol styles for groups (in particular, deskBracket)
 - since the staff object has a "labelref" property, should it not also have a "part" property?
 - staff group objects need a labelref alternative (and "part" that it references).
+- labelRef values are not enforced by the schema
 - there needs to be a mechanism to specify automatic name/shortName for "labelref" values.
+- should "systems" be a required propery of the page object?
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,7 @@ static int showHelpPage(const std::string_view& programName)
     std::cout << "  --help                          Show this help message and exit" << std::endl;
     std::cout << "  --recursive                     Recursively search subdirectories of the input directory" << std::endl;
     std::cout << "  --schema [file-path]            Validate against this json schema file rather than the embedded one." << std::endl;
+    std::cout << "  --schema-only                   Only validate against the schema. Perform no other validation checks." << std::endl;
     std::cout << "  --version                       Show program version and exit" << std::endl;
     std::cout << std::endl;
 

--- a/src/mnxvalidate.cpp
+++ b/src/mnxvalidate.cpp
@@ -372,7 +372,7 @@ static void validateScores(json jsonData, const MnxValidateContext& context)
 {
     bool valid = true;
     if (nodeExists(jsonData, "scores", false)) {  // scores are *not* required in MNX
-        if (!jsonData["layouts"].is_array()) {
+        if (!jsonData["scores"].is_array()) {
             throw std::invalid_argument("Scores node in validated JSON is not an array!");
         }
         for (const auto& score : jsonData["scores"]) {

--- a/src/mnxvalidate.cpp
+++ b/src/mnxvalidate.cpp
@@ -295,10 +295,7 @@ static void validateParts(json jsonData, const MnxValidateContext& context)
                 }
                 partName = " \"" + partName + "\"";
             }
-            size_t numMeasures = 0;
-            if (part.contains("measures")) {
-                numMeasures = part["measures"].size();
-            }
+            size_t numMeasures = part.contains("measures") ? part["measures"].size() : 0;
             if (numMeasures != context.measCount) {
                 context.logMessage(LogMsg() << "Part" << partName << " contains a different number of measures (" + std::to_string(numMeasures)
                         + ") than are defined globally (" + std::to_string(context.measCount) + ").", LogSeverity::Error);
@@ -353,8 +350,7 @@ static void validateLayouts(json jsonData, const MnxValidateContext& context)
                                                         << std::to_string(staffNum) << ") for part " << source["part"] << ".", LogSeverity::Error);
                                                 valid = false;
                                             }
-                                        }
-                                        else {
+                                        } else {
                                             valid = false;
                                         }
                                     }                                    

--- a/src/mnxvalidate.cpp
+++ b/src/mnxvalidate.cpp
@@ -260,11 +260,7 @@ static void validateGlobal(json jsonData, const MnxValidateContext& context)
             for (size_t x = 0; x < global["measures"].size(); x++) {
                 const auto& meas = global["measures"][x];
                 context.measCount++;
-                if (meas.contains("index")) {
-                    measureId = meas["index"].get<int>();
-                } else {
-                    measureId++;
-                }
+                measureId = meas.contains("index") ? meas["index"].get<int>() : measureId + 1;
                 auto it = context.mnxMeasureList.find(measureId);
                 if (it == context.mnxMeasureList.end()) {
                     context.mnxMeasureList.emplace(measureId, x);

--- a/src/mnxvalidate.h
+++ b/src/mnxvalidate.h
@@ -146,6 +146,38 @@ public:
 #endif
     }
 
+    bool addKey(const std::string& key, std::unordered_set<std::string>& keySet, const std::string& setDescription) const
+    {
+        auto it = keySet.find(key);
+        if (it == keySet.end()) {
+            keySet.insert(key);
+            return true;
+        } else {
+            logMessage(LogMsg() << "more than one " << setDescription << " with id \"" << key << "\" exists.", LogSeverity::Error);
+        }
+        return false;
+    }
+
+    bool checkPart(const std::string& partId, const std::string& parentDesc) const
+    {
+        auto it = mnxPartList.find(partId);
+        if (it == mnxPartList.end()) {
+            logMessage(LogMsg() << parentDesc << " references non-existent part \"" << partId << "\".", LogSeverity::Error);
+            return false;
+        }
+        return true;
+    }
+
+    bool checkLayout(const std::string& layoutId, const std::string& parentDesc) const
+    {
+        auto it = mnxLayoutList.find(layoutId);
+        if (it == mnxLayoutList.end()) {
+            logMessage(LogMsg() << parentDesc << " references non-existent layout \"" << layoutId << "\".", LogSeverity::Error);
+            return false;
+        }
+        return true;
+    }
+
 private:
     void logMessage(LogMsg&& msg, bool alwaysShow, LogSeverity severity = LogSeverity::Info) const;
 };
@@ -159,7 +191,7 @@ inline bool nodeExists(json jsonData, const std::string_view& nodeName, bool req
 {
     bool retval = jsonData.contains(nodeName);
     if (required && !retval) {
-        throw std::invalid_argument("Validated JSON node does not contain required value " + std::string(nodeName) + '!');
+        throw std::invalid_argument("Validated JSON node does not contain required value \"" + std::string(nodeName) + "\"!");
     }
     return retval;
 }

--- a/src/mnxvalidate.h
+++ b/src/mnxvalidate.h
@@ -112,6 +112,8 @@ public:
     bool schemaOnly{};
 
     mutable std::filesystem::path inputFilePath;
+    mutable std::map<int, size_t> mnxMeasureList; // key: measId; value: index of measure in global measure array
+    mutable size_t measCount{}; // can be different than mnxMeasureList.size() if there is a duplicate key error
     mutable std::unordered_set<std::string> mnxPartList;
     mutable std::unordered_set<std::string> mnxLayoutList;
 
@@ -178,8 +180,27 @@ public:
         return true;
     }
 
+    std::optional<size_t> getMeasureIndex(int measureId, const std::string& parentDesc) const
+    {
+        auto it = mnxMeasureList.find(measureId);
+        if (it == mnxMeasureList.end()) {
+            logMessage(LogMsg() << parentDesc << " references non-existent measure " << std::to_string(measureId) << ".", LogSeverity::Error);
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
 private:
     void logMessage(LogMsg&& msg, bool alwaysShow, LogSeverity severity = LogSeverity::Info) const;
+
+    void resetForFile(const std::filesystem::path& inpFile) const
+    {
+        inputFilePath = inpFile;
+        mnxMeasureList.clear();
+        measCount = 0;
+        mnxPartList.clear();
+        mnxLayoutList.clear();
+    }
 };
 
 std::string getTimeStamp(const std::string& fmt);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ if(mnxvalidate_BUILD_TESTING)
     add_executable(mnxvalidate_tests
         mnxvalidatetests.cpp
         test_examples.cpp
+        test_global.cpp
         test_layouts.cpp
         test_parts.cpp
         test_schema.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,10 @@ if(mnxvalidate_BUILD_TESTING)
     add_executable(mnxvalidate_tests
         mnxvalidatetests.cpp
         test_examples.cpp
+        test_layouts.cpp
+        test_parts.cpp
         test_schema.cpp
+        test_scores.cpp
         test_logging.cpp
         ${MNXVALIDATE_SOURCES}
     )

--- a/tests/data/inputs/errors/duplicate_layouts.json
+++ b/tests/data/inputs/errors/duplicate_layouts.json
@@ -1,0 +1,166 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ],
+    "layouts": [
+        {
+            "id": "S0-ScrVw",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "S0-ScrVw",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/duplicate_measures.json
+++ b/tests/data/inputs/errors/duplicate_measures.json
@@ -1,0 +1,39 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": [
+            {
+                "index": 1
+            },
+            {},
+            {
+                "index": 1
+            },
+            {}
+        ]
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2,
+            "measures": [
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/duplicate_parts.json
+++ b/tests/data/inputs/errors/duplicate_parts.json
@@ -1,0 +1,22 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P1",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ]
+}

--- a/tests/data/inputs/errors/layout_invalid_staffnum.json
+++ b/tests/data/inputs/errors/layout_invalid_staffnum.json
@@ -1,0 +1,69 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": [
+            {},
+            {},
+            {},
+            {}
+        ]
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2,
+            "measures": [
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                }
+            ]
+        }
+    ],
+    "layouts": [
+        {
+            "id": "badStaff",
+            "content": [
+            {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 3,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/layout_with_bad_part.json
+++ b/tests/data/inputs/errors/layout_with_bad_part.json
@@ -1,0 +1,166 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ],
+    "layouts": [
+        {
+            "id": "S0-ScrVw",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P-does-not-exist",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "S0-Sys1",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/measures_mismatch.json
+++ b/tests/data/inputs/errors/measures_mismatch.json
@@ -1,0 +1,36 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": [
+            {
+                "index": 1
+            },
+            {},
+            {}
+        ]
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2,
+            "measures": [
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                },
+                {
+                   "sequences": []
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/score_bad_layout.json
+++ b/tests/data/inputs/errors/score_bad_layout.json
@@ -1,0 +1,110 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ],
+    "layouts": [
+        {
+            "id": "S0-ScrVw",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "scores": [
+        {
+            "layout": "does-not-exist",
+            "name": "Score",
+            "pages": [
+                {
+                    "systems": [
+                        {
+                            "measure": 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/score_layoutchange_bad_layout.json
+++ b/tests/data/inputs/errors/score_layoutchange_bad_layout.json
@@ -1,0 +1,123 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ],
+    "layouts": [
+        {
+            "id": "S0-ScrVw",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "scores": [
+        {
+            "name": "Score",
+            "pages": [
+                {
+                    "systems": [
+                        {
+                            "measure": 1,
+                            "layoutChanges": [
+                                {
+                                    "layout": "does-not-exist",
+                                    "location": {
+                                        "bar": 1,
+                                        "position": {
+                                            "fraction": [
+                                                1,
+                                                4
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/score_mmrest_bad_span.json
+++ b/tests/data/inputs/errors/score_mmrest_bad_span.json
@@ -1,0 +1,34 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": [
+            {}
+        ]
+    },
+    "parts": [
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2,
+            "measures": [
+                {
+                    "sequences": []
+                }
+            ]
+        }
+    ],
+    "scores": [
+        {            
+            "name": "Score",
+            "multimeasureRests": [
+                {
+                    "start": 1,
+                    "duration": 3
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/score_mmrest_bad_start.json
+++ b/tests/data/inputs/errors/score_mmrest_bad_start.json
@@ -1,0 +1,34 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": [
+            {}
+        ]
+    },
+    "parts": [
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2,
+            "measures": [
+                {
+                    "sequences": []
+                }
+            ]
+        }
+    ],
+    "scores": [
+        {            
+            "name": "Score",
+            "multimeasureRests": [
+                {
+                    "start": 3,
+                    "duration": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/score_page_bad_layout.json
+++ b/tests/data/inputs/errors/score_page_bad_layout.json
@@ -1,0 +1,110 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ],
+    "layouts": [
+        {
+            "id": "S0-ScrVw",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "scores": [
+        {
+            "name": "Score",
+            "pages": [
+                {
+                    "layout": "does-not-exist",
+                    "systems": [
+                        {
+                            "measure": 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/score_system_bad_layout.json
+++ b/tests/data/inputs/errors/score_system_bad_layout.json
@@ -1,0 +1,110 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ],
+    "layouts": [
+        {
+            "id": "S0-ScrVw",
+            "content": [
+                {
+                    "type": "group",
+                    "content": [
+                        {
+                            "type": "group",
+                            "label": "Organ",
+                            "symbol": "brace",
+                            "content": [
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "staff",
+                                    "sources": [
+                                        {
+                                            "part": "P1",
+                                            "staff": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P1",
+                                    "staff": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "label": "Harpsichord 1",
+                    "symbol": "brace",
+                    "content": [
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 1,
+                                    "label": "RH"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "staff",
+                            "sources": [
+                                {
+                                    "part": "P2",
+                                    "staff": 2,
+                                    "label": "LH"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "scores": [
+        {
+            "name": "Score",
+            "pages": [
+                {
+                    "systems": [
+                        {
+                            "layout": "does-not-exist",
+                            "measure": 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/errors/score_system_bad_layout.json
+++ b/tests/data/inputs/errors/score_system_bad_layout.json
@@ -3,20 +3,32 @@
         "version": 1
     },
     "global": {
-        "measures": []
+        "measures": [
+            {}
+        ]
     },
     "parts": [
         {
             "id": "P1",
             "name": "Organ",
             "shortName": "Org.",
-            "staves": 3
+            "staves": 3,
+            "measures": [
+                {
+                    "sequences": []
+                }
+            ]
         },
         {
             "id": "P2",
             "name": "Harpsichord 1",
             "shortName": "Hpschd. 1",
-            "staves": 2
+            "staves": 2,
+            "measures": [
+                {
+                    "sequences": []
+                }
+            ]
         }
     ],
     "layouts": [

--- a/tests/data/inputs/errors/score_system_bad_measure.json
+++ b/tests/data/inputs/errors/score_system_bad_measure.json
@@ -1,0 +1,36 @@
+{
+    "mnx": {
+        "version": 1
+    },
+    "global": {
+        "measures": []
+    },
+    "parts": [
+        {
+            "id": "P1",
+            "name": "Organ",
+            "shortName": "Org.",
+            "staves": 3
+        },
+        {
+            "id": "P2",
+            "name": "Harpsichord 1",
+            "shortName": "Hpschd. 1",
+            "staves": 2
+        }
+    ],
+    "scores": [
+        {
+            "name": "Score",
+            "pages": [
+                {
+                    "systems": [
+                        {
+                            "measure": 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/inputs/examples/orchestral_layout.json
+++ b/tests/data/inputs/examples/orchestral_layout.json
@@ -3,7 +3,11 @@
        "version": 1
     },
     "global": {
-       "measures": []
+       "measures": [
+          {},
+          {},
+          {}
+       ]
     },
     "layouts": [
        {
@@ -283,43 +287,186 @@
     ],
     "parts": [
        {
+          "measures": [
+             {
+                "sequences": []
+             },
+             {
+                "sequences": []
+             },
+             {
+                "sequences": []
+             }
+          ],
           "id": "Klar1"
        },
        {
-          "id": "Klar2"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Klar2"
        },
        {
-          "id": "Klar3"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Klar3"
        },
        {
-          "id": "Horn1"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Horn1"
        },
        {
-          "id": "Horn2"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Horn2"
        },
        {
-          "id": "Horn3"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Horn3"
        },
        {
-          "id": "Horn4"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Horn4"
        },
        {
-          "id": "Harfe",
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Harfe",
           "staves": 2
        },
        {
-          "id": "Violin1"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Violin1"
        },
        {
-          "id": "Violin2"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Violin2"
        },
        {
-          "id": "Viola"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Viola"
        },
        {
-          "id": "Cello"
+         "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ],
+         "id": "Cello"
        },
        {
+          "measures": [
+             {
+                "sequences": []
+             },
+             {
+                "sequences": []
+             },
+             {
+                "sequences": []
+             }
+          ],
           "id": "Kontra"
        }
     ],
@@ -335,7 +482,7 @@
                    },
                    {
                       "layout": "secondSystem",
-                      "measure": 7
+                      "measure": 3
                    }
                 ]
              }

--- a/tests/data/inputs/examples/organ_layout.json
+++ b/tests/data/inputs/examples/organ_layout.json
@@ -15,7 +15,9 @@
                 "count": 3,
                 "unit": 4
              }
-          }
+          },
+          {},
+          {}
        ]
     },
     "layouts": [
@@ -296,6 +298,12 @@
                       "voice": "Pedal"
                    }
                 ]
+             },
+             {
+                "sequences": []
+             },
+             {
+                "sequences": []
              }
           ],
           "staves": 3
@@ -327,7 +335,7 @@
                    },
                    {
                       "layout": "organ3StaffSplitOber",
-                      "measure": 6
+                      "measure": 3
                    }
                 ]
              }

--- a/tests/data/inputs/examples/system_layouts.json
+++ b/tests/data/inputs/examples/system_layouts.json
@@ -3,7 +3,12 @@
        "version": 1
     },
     "global": {
-        "measures": []
+       "measures": [
+          {},
+          {},
+          {},
+          {}
+       ]
     },
     "layouts": [
        {
@@ -180,32 +185,116 @@
        {
           "id": "fl1",
           "name": "Flute 1",
-          "shortName": "1"
-       },
+          "shortName": "1",
+          "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ]
+         },
        {
           "id": "fl2",
           "name": "Flute 2",
-          "shortName": "2"
+          "shortName": "2",
+          "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ]
        },
        {
           "id": "fl3",
           "name": "Flute 3",
-          "shortName": "3"
+          "shortName": "3",
+          "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ]
        },
        {
           "id": "ob1",
           "name": "Oboe 1",
-          "shortName": "1"
+          "shortName": "1",
+          "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ]
        },
        {
           "id": "ob2",
           "name": "Oboe 2",
-          "shortName": "2"
+          "shortName": "2",
+          "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ]
        },
        {
           "id": "piano",
           "name": "Piano",
-          "staves": 2
+          "staves": 2,
+          "measures": [
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            },
+            {
+               "sequences": []
+            }
+         ]
        }
     ],
     "scores": [

--- a/tests/data/inputs/mnxvalidate-logs/mnxvalidate-20250201-073145.log
+++ b/tests/data/inputs/mnxvalidate-logs/mnxvalidate-20250201-073145.log
@@ -1,0 +1,22 @@
+[2025-02-01 07:31:45] ======= START =======
+[2025-02-01 07:31:45] mnxvalidate executed with the following arguments:
+[2025-02-01 07:31:45] mnxvalidate /Volumes/RGP Data Drive/Robert Folder/Robert/Dev Projects (XCode, Lazarus)/mnx/mnxvalidate/tests/data/inputs/generic_nonascii_其れ.json --schema --schema-only /Volumes/RGP Data Drive/Robert Folder/Robert/Dev Projects (XCode, Lazarus)/mnx/mnxvalidate/tests/data/inputs/generic_schema.json 
+[2025-02-01 07:31:45] 
+[2025-02-01 07:31:45] ======================================================================================================================================================
+[2025-02-01 07:31:45] Processing File: /Volumes/RGP Data Drive/Robert Folder/Robert/Dev Projects (XCode, Lazarus)/mnx/mnxvalidate/tests/data/inputs/generic_nonascii_其れ.json
+[2025-02-01 07:31:45] ======================================================================================================================================================
+[2025-02-01 07:31:45] generic_nonascii_其れ.json Validate JSON /Volumes/RGP Data Drive/Robert Folder/Robert/Dev Projects (XCode, Lazarus)/mnx/mnxvalidate/tests/data/inputs/generic_nonascii_其れ.json
+[2025-02-01 07:31:45] generic_nonascii_其れ.json [***ERROR***] Invalid argument: At  of {"age":34,"email":"john.smith@example.com","isActive":false,"name":"John Smith","tags":["manager","mentor"]} - required property 'global' not found in object
+
+[2025-02-01 07:31:45] generic_nonascii_其れ.json [***ERROR***] generic_nonascii_其れ.json is not valid against the MNX schema.
+[2025-02-01 07:31:45] 
+[2025-02-01 07:31:45] =================================================================================================================================================
+[2025-02-01 07:31:45] Processing File: /Volumes/RGP Data Drive/Robert Folder/Robert/Dev Projects (XCode, Lazarus)/mnx/mnxvalidate/tests/data/inputs/generic_schema.json
+[2025-02-01 07:31:45] =================================================================================================================================================
+[2025-02-01 07:31:45] generic_schema.json Validate JSON /Volumes/RGP Data Drive/Robert Folder/Robert/Dev Projects (XCode, Lazarus)/mnx/mnxvalidate/tests/data/inputs/generic_schema.json
+[2025-02-01 07:31:45] generic_schema.json [***ERROR***] Invalid argument: At  of {"$defs":{"person":{"additionalProperties":false,"properties":{"age":{"description":"The age of the person in years.","minimum":0,"type":"integer"},"email":{"description":"The email address of the person.","type":"string"},"isActive":{"description":"Indicates if the person is currently active.","type":"boolean"},"name":{"description":"The name of the person.","type":"string"},"tags":{"description":"A list of tags associated with the person.","items":{"type":"string"},"type":"array"}},"required":["name","email"],"type":"object"}},"$ref":"#/$defs/person","$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"} - required property 'global' not found in object
+
+[2025-02-01 07:31:45] generic_schema.json [***ERROR***] generic_schema.json is not valid against the MNX schema.
+[2025-02-01 07:31:45] 
+[2025-02-01 07:31:45] mnxvalidate processing complete
+[2025-02-01 07:31:45] ======== END ========

--- a/tests/test_global.cpp
+++ b/tests/test_global.cpp
@@ -29,32 +29,12 @@
 
 using namespace mnxvalidate;
 
-TEST(Layouts, DuplicateId)
+TEST(Global, DuplicateMeasures)
 {
     setupTestDataPaths();
-    std::filesystem::path inputPath = getInputPath() / "errors" / "duplicate_layouts.json";
+    std::filesystem::path inputPath = getInputPath() / "errors" / "duplicate_measures.json";
     ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
-    checkStderr({ std::string("duplicate_layouts.json"), "more than one layout with id \"S0-ScrVw\"" }, [&]() {
-        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
-    });
-}
-
-TEST(Layouts, NonexistentPartId)
-{
-    setupTestDataPaths();
-    std::filesystem::path inputPath = getInputPath() / "errors" / "layout_with_bad_part.json";
-    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
-    checkStderr({ std::string("layout_with_bad_part.json"), "\"S0-ScrVw\" references non-existent part \"P-does-not-exist\"" }, [&]() {
-        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
-    });
-}
-
-TEST(Layouts, NonexistentStaffNumber)
-{
-    setupTestDataPaths();
-    std::filesystem::path inputPath = getInputPath() / "errors" / "layout_invalid_staffnum.json";
-    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
-    checkStderr({ std::string("layout_invalid_staffnum.json"), "Layout \"badStaff\" references non-existent part \"P2\"" }, [&]() {
+    checkStderr({ std::string("duplicate_measures.json"), "measure index 1 is duplicated at location 0 and 2" }, [&]() {
         EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
     });
 }

--- a/tests/test_layouts.cpp
+++ b/tests/test_layouts.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <string>
+#include <filesystem>
+#include <iterator>
+
+#include "gtest/gtest.h"
+#include "mnxvalidate.h"
+#include "test_utils.h"
+
+using namespace mnxvalidate;
+
+TEST(Layouts, DuplicateId)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "duplicate_layouts.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("duplicate_layouts.json"), "more than one layout with id \"S0-ScrVw\"" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}
+
+TEST(Layouts, NonexistentPartId)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "layout_with_bad_part.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("layout_with_bad_part.json"), "\"S0-ScrVw\" references non-existent part \"P-does-not-exist\"" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}

--- a/tests/test_parts.cpp
+++ b/tests/test_parts.cpp
@@ -38,3 +38,13 @@ TEST(Parts, DuplicateId)
         EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
     });
 }
+
+TEST(Parts, MeasuresMismatch)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "measures_mismatch.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("measures_mismatch.json"), "contains a different number of measures (4) than are defined globally (3)" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}

--- a/tests/test_parts.cpp
+++ b/tests/test_parts.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <string>
+#include <filesystem>
+#include <iterator>
+
+#include "gtest/gtest.h"
+#include "mnxvalidate.h"
+#include "test_utils.h"
+
+using namespace mnxvalidate;
+
+TEST(Parts, DuplicateId)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "duplicate_parts.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("duplicate_parts.json"), "more than one part with id \"P1\"" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}

--- a/tests/test_schema.cpp
+++ b/tests/test_schema.cpp
@@ -33,7 +33,7 @@ TEST(Schema, InputSchemaValid)
 {
     setupTestDataPaths();
     std::filesystem::path inputPath = getInputPath() / utils::utf8ToPath("generic_nonascii_其れ.json");
-    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--schema", (getInputPath() / "generic_schema.json").u8string() };
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--schema", (getInputPath() / "generic_schema.json").u8string(), "--schema-only" };
     checkStderr({ "Processing", inputPath.filename().u8string(), "is valid" }, [&]() {
         EXPECT_EQ(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
     });

--- a/tests/test_scores.cpp
+++ b/tests/test_scores.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <string>
+#include <filesystem>
+#include <iterator>
+
+#include "gtest/gtest.h"
+#include "mnxvalidate.h"
+#include "test_utils.h"
+
+using namespace mnxvalidate;
+
+TEST(Scores, InvalidScoreLayoutId)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "score_bad_layout.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("score_bad_layout.json"), "references non-existent layout \"does-not-exist\"" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}
+
+TEST(Scores, InvalidScorePageLayoutId)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "score_page_bad_layout.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("score_page_bad_layout.json"), "Page[0]", "references non-existent layout \"does-not-exist\"" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}
+
+TEST(Scores, InvalidScoreSystemLayoutId)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "score_system_bad_layout.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("score_system_bad_layout.json"), "System[0]", "references non-existent layout \"does-not-exist\"" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}
+
+TEST(Scores, InvalidScoreLayoutChangeLayoutId)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "score_layoutchange_bad_layout.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("score_layoutchange_bad_layout.json"), "Layout change[0]", "references non-existent layout \"does-not-exist\"" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}

--- a/tests/test_scores.cpp
+++ b/tests/test_scores.cpp
@@ -69,6 +69,32 @@ TEST(Scores, InvalidScoreLayoutChangeLayoutId)
     });
 }
 
-// MultimeasureRestStart
-// MultimeasureRestSpan
-// SystemStartMeasure
+TEST(Scores, InvalidMMRestStartMeasure)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "score_mmrest_bad_start.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("score_mmrest_bad_start.json"), "Multimeasure rest in score \"Score\" references non-existent measure 3" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}
+
+TEST(Scores, InvalidMMRestSpan)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "score_mmrest_bad_span.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("score_mmrest_bad_span.json"), "Multimeasure rest at measure 1 in score \"Score\" spans non-existent measures" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}
+
+TEST(Scores, InvalidSystemStartMeasure)
+{
+    setupTestDataPaths();
+    std::filesystem::path inputPath = getInputPath() / "errors" / "score_system_bad_measure.json";
+    ArgList args = { MNXVALIDATE_NAME, inputPath.u8string(), "--no-log" };
+    checkStderr({ std::string("score_system_bad_measure.json"), "System[0] in page[0] in score \"Score\" references non-existent measure 1" }, [&]() {
+        EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
+    });
+}

--- a/tests/test_scores.cpp
+++ b/tests/test_scores.cpp
@@ -68,3 +68,7 @@ TEST(Scores, InvalidScoreLayoutChangeLayoutId)
         EXPECT_NE(mnxValidateTestMain(args.argc(), args.argv()), 0) << "validate " << inputPath.u8string();
     });
 }
+
+// MultimeasureRestStart
+// MultimeasureRestSpan
+// SystemStartMeasure


### PR DESCRIPTION
This PR adds semantic checks (i.e., checks beyond schema validation) for `scores`, `layouts`, and `parts`.
