### PR TITLE
fix compiler issues with C++17

### DIFF
--- a/src/mnxvalidate.cpp
+++ b/src/mnxvalidate.cpp
@@ -85,7 +85,12 @@ std::string getTimeStamp(const std::string& fmt)
 #ifdef _WIN32
     localtime_s(&localTime, &time_t_now); // Windows
 #else
-    localtime_r(&time_t_now, &localTime); // Linux/Unix
+    std::tm* tmPtr = localtime(&time_t_now); // POSIX: localtime is thread-safe per thread
+    if (tmPtr) {
+        localTime = *tmPtr;
+    } else {
+        return {}; // Handle failure gracefully
+    }
 #endif
     std::ostringstream timestamp;
     timestamp << std::put_time(&localTime, fmt.c_str());

--- a/src/mnxvalidate.h
+++ b/src/mnxvalidate.h
@@ -75,8 +75,25 @@ using arg_string = std::string;
 #endif
 
 using Buffer = std::vector<char>;
-using LogMsg = std::stringstream;
 using json = nlohmann::json;
+
+/// @class LogMsg
+/// @brief Stringstream class that allows rvalues to be streamed to logMessage
+class LogMsg : public std::stringstream
+{
+public:
+    using std::stringstream::stringstream;
+
+    LogMsg(const LogMsg& src) : std::stringstream(src.str()) {}
+
+    // Override operator<< to return LogMsg&
+    template <typename T>
+    LogMsg&& operator<<(const T& value)
+    {
+        static_cast<std::stringstream&>(*this) << value;
+        return std::move(*this); // Ensure the return type is LogMsg&
+    }
+};
 
 /// @brief defines log message severity
 enum class LogSeverity

--- a/src/mnxvalidate.h
+++ b/src/mnxvalidate.h
@@ -79,33 +79,24 @@ using json = nlohmann::json;
 
 /// @class LogMsg
 /// @brief Stringstream class that allows rvalues to be streamed to logMessage
-class LogMsg : public std::stringstream
-{
+class LogMsg {
+private:
+    std::stringstream stream;
+
 public:
-    using std::stringstream::stringstream;
+    LogMsg() = default;
+    LogMsg(const LogMsg& other) : stream(other.stream.str()) {} // Copy constructor
+    LogMsg(LogMsg&& other) noexcept : stream(std::move(other.stream)) {} // Move constructor
 
-    // Copy Constructor
-    LogMsg(const LogMsg& other) : std::stringstream()
-    {
-        this->str(other.str());  // Copy the string content
-        this->setstate(other.rdstate());  // Copy stream state
-    }
+    // Allow retrieval of the internal stream content
+    std::string str() const { return stream.str(); }
 
-    // Custom Copy Assignment Operator
-    LogMsg& operator=(const LogMsg& other)
-    {
-        if (this != &other) {
-            this->str(other.str()); // Copy the string content
-            this->setstate(other.rdstate());  // Copy stream state
-        }
-        return *this;
-    }
+    void flush() { stream.flush(); }
 
-    // Perfectly forwarding operator<< to handle both lvalues and rvalues correctly
+    // Override operator<< to ensure LogMsg&& is always returned
     template <typename T>
-    LogMsg&& operator<<(T&& value)
-    {
-        static_cast<std::stringstream&>(*this) << std::forward<T>(value);
+    LogMsg&& operator<<(const T& value) {
+        stream << value;
         return std::move(*this);
     }
 };

--- a/src/mnxvalidate.h
+++ b/src/mnxvalidate.h
@@ -79,24 +79,32 @@ using json = nlohmann::json;
 
 /// @class LogMsg
 /// @brief Stringstream class that allows rvalues to be streamed to logMessage
-class LogMsg : public std::stringstream {
+class LogMsg : public std::stringstream
+{
 public:
     using std::stringstream::stringstream;
 
-    // Custom Copy Constructor (to allow copying)
-    LogMsg(const LogMsg& other) : std::stringstream(other.str()) {}
+    // Copy Constructor
+    LogMsg(const LogMsg& other) : std::stringstream()
+    {
+        this->str(other.str());  // Copy the string content
+        this->setstate(other.rdstate());  // Copy stream state
+    }
 
     // Custom Copy Assignment Operator
-    LogMsg& operator=(const LogMsg& other) {
+    LogMsg& operator=(const LogMsg& other)
+    {
         if (this != &other) {
             this->str(other.str()); // Copy the string content
+            this->setstate(other.rdstate());  // Copy stream state
         }
         return *this;
     }
 
     // Perfectly forwarding operator<< to handle both lvalues and rvalues correctly
     template <typename T>
-    LogMsg&& operator<<(T&& value) {
+    LogMsg&& operator<<(T&& value)
+    {
         static_cast<std::stringstream&>(*this) << std::forward<T>(value);
         return std::move(*this);
     }

--- a/src/mnxvalidate.h
+++ b/src/mnxvalidate.h
@@ -79,19 +79,26 @@ using json = nlohmann::json;
 
 /// @class LogMsg
 /// @brief Stringstream class that allows rvalues to be streamed to logMessage
-class LogMsg : public std::stringstream
-{
+class LogMsg : public std::stringstream {
 public:
     using std::stringstream::stringstream;
 
-    LogMsg(const LogMsg& src) : std::stringstream(src.str()) {}
+    // Custom Copy Constructor (to allow copying)
+    LogMsg(const LogMsg& other) : std::stringstream(other.str()) {}
 
-    // Override operator<< to return LogMsg&
+    // Custom Copy Assignment Operator
+    LogMsg& operator=(const LogMsg& other) {
+        if (this != &other) {
+            this->str(other.str()); // Copy the string content
+        }
+        return *this;
+    }
+
+    // Perfectly forwarding operator<< to handle both lvalues and rvalues correctly
     template <typename T>
-    LogMsg&& operator<<(const T& value)
-    {
-        static_cast<std::stringstream&>(*this) << value;
-        return std::move(*this); // Ensure the return type is LogMsg&
+    LogMsg&& operator<<(T&& value) {
+        static_cast<std::stringstream&>(*this) << std::forward<T>(value);
+        return std::move(*this);
     }
 };
 

--- a/tests/mnxvalidatetests.cpp
+++ b/tests/mnxvalidatetests.cpp
@@ -66,7 +66,7 @@ void checkStderr(const std::vector<std::string>& expectedMessages, std::function
                 << "Message \"" << expectedMessage << "\" not found. Actual: " << capturedErrors;
         }
     }
-};
+}
 
 void checkStdout(const std::vector<std::string>& expectedMessages, std::function<void()> callback)
 {


### PR DESCRIPTION
- got rid of spurious `;`
- use `localtime` instead of `localtime_r`.
- refactor `LogMsg` as a class to avoid need to upcast `ostream&` to `stringstream&`.
